### PR TITLE
dont PC when TTmove is quiet and nullfailed

### DIFF
--- a/src/search.cc
+++ b/src/search.cc
@@ -451,7 +451,10 @@ int Search::_negaMax(const Board &board, pV *up_pV, int depth, int alpha, int be
   MovePicker movePicker(&_orderingInfo, &board, legalMoves, hashedMove.getMoveINT(), board.getActivePlayer(), ply, pMove);
 
   // Probcut
-  if (!pvNode && depth >= 5 && alpha < WON_IN_X){
+  if (!pvNode &&
+       depth >= 5 &&
+       !(quietTT && failedNull) &&
+       alpha < WON_IN_X){
     int pcBeta = beta + 200;
     while (movePicker.hasNext()){
       Move move = movePicker.getNext();


### PR DESCRIPTION
If null_move failed and TTmove of the current position is quiet, it is unreasonable to try probcut, so dont do it