### PR TITLE
dont use ppE and lcE for the ttMove now we have sE

### DIFF
--- a/src/orderinginfo.cc
+++ b/src/orderinginfo.cc
@@ -9,6 +9,7 @@ void OrderingInfo::clearAllHistory(){
   std::memset(_history, 0, sizeof(_history));
   std::memset(_captureHistory, 0, sizeof(_captureHistory));
   std::memset(_counterMove, 0, sizeof(_counterMove));
+  std::memset(_counterMoveHistory, 0, sizeof(_counterMoveHistory));
   std::memset(_killer1, 0, sizeof(_killer1));
   std::memset(_killer2, 0, sizeof(_killer2));
 }

--- a/src/search.cc
+++ b/src/search.cc
@@ -560,17 +560,7 @@ int Search::_negaMax(const Board &board, pV *up_pV, int depth, int alpha, int be
           tDepth++;
         }
 
-        // 6.1. Passed pawn push extention
-        // In the late game  we fear that we may miss
-        // some pawn promotions near the leafs of the search tree
-        // Thus we extend in the endgame pushes of the non-blocked
-        // passers that are near the middle of the board
-        // Extend more if null move failed
-        if (depth <= 8 && board.isEndGamePosition() && move.isItPasserPush(board)){
-              tDepth += 1;
-            }
-
-        // 6.2 Singular move extention
+        // 6.1 Singular move extention
         // At high depth if we have the TT move, and we are certain
         // that non other moves are even close to it, extend this move
         if (!AreWeInCheck &&
@@ -588,11 +578,26 @@ int Search::_negaMax(const Board &board, pV *up_pV, int depth, int alpha, int be
               }
             }
 
+        // 6.2. Passed pawn push extention
+        // In the late game  we fear that we may miss
+        // some pawn promotions near the leafs of the search tree
+        // Thus we extend in the endgame pushes of the non-blocked
+        // passers that are near the middle of the board
+        // Extend more if null move failed
+        if (depth <= 8 &&
+            board.isEndGamePosition() &&
+            move.isItPasserPush(board) &&
+            probedHASHentry.move != move.getMoveINT()){
+              tDepth += 1;
+            }
+
         // 6.3 Last capture extention
         // In the endgame positions we extend any non-pawn captures
         // It seems benefitial as we calculate resulting endgame more accurately
-        if (!isQuiet && board.isEndGamePosition() &&
-            move.getCapturedPieceType() != PAWN){
+        if (!isQuiet &&
+            board.isEndGamePosition() &&
+            move.getCapturedPieceType() != PAWN &&
+            probedHASHentry.move != move.getMoveINT()){
               tDepth++;
             }
 


### PR DESCRIPTION
Now that we have a low-depth singular, it seems pretty useless to try other extentions on the 1st move, so simplify it.
Also fixes annoying bench bug (non-functional).