### PR TITLE
Add missing #include <cstdint> directives

### DIFF
--- a/src/bitbase.cc
+++ b/src/bitbase.cc
@@ -20,6 +20,7 @@
 #include "eval.h"
 #include "bitutils.h"
 #include "attacks.h"
+#include <cstdint>
 #include <cstring>
 
 uint8_t KPK_Bitbase[KPK_SIZE / 8];

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -21,6 +21,7 @@
 #include "defs.h"
 #include "board.h"
 #include "bitutils.h"
+#include <cstdint>
 
 
 #define EG_HASH_SIZE        (8192)

--- a/src/eval.h
+++ b/src/eval.h
@@ -22,6 +22,7 @@
 #include "movegen.h"
 #include "bitutils.h"
 #include "endgame.h"
+#include <cstdint>
 
 #define gS(opS, egS) (int)((unsigned int)(opS) << 16) + (egS)
 #define opS(gS) (int16_t)((uint16_t)((unsigned)((gS) + 0x8000) >> 16))

--- a/src/orderinginfo.cc
+++ b/src/orderinginfo.cc
@@ -16,6 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "orderinginfo.h"
+#include <cstdint>
 #include <cstring>
 
 OrderingInfo::OrderingInfo() {

--- a/src/orderinginfo.h
+++ b/src/orderinginfo.h
@@ -22,6 +22,7 @@
 #include "defs.h"
 #include "movegen.h"
 #include "move.h"
+#include <cstdint>
 
 #define cmhCalculateIndex(moveInt) (((moveInt & 0x7) + ((moveInt >> 15) & 0x3f) * 6))
 

--- a/src/searchdata.h
+++ b/src/searchdata.h
@@ -20,6 +20,7 @@
 
 #include "defs.h"
 #include "move.h"
+#include <cstdint>
 
 struct SEARCH_Data
 {

--- a/src/transptable.cc
+++ b/src/transptable.cc
@@ -17,6 +17,7 @@
 */
 #include "transptable.h"
 #include "transptableentry.h"
+#include <cstdint>
 
 HASH * myHASH;
 

--- a/src/transptableentry.h
+++ b/src/transptableentry.h
@@ -19,6 +19,7 @@
 #define TRANSPTABLEENTRY_H
 
 #include "move.h"
+#include <cstdint>
 
 /**
  * @brief Represent CuttOffState of the node saved in the transposition table.

--- a/src/tuning.h
+++ b/src/tuning.h
@@ -16,6 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "eval.h"
+#include <cstdint>
 
 #ifdef _TUNE_
     #define TRACK (1)


### PR DESCRIPTION
Some of the source and header files that use fixed-width integer types are missing the corresponding \#include \<cstdint\> directives. This breaks the build on Ubuntu 23.10 (GCC 13). Fix this by adding the missing directives to all files that use the said fixed-width integer types.

**

I spotted this issue when upgrading my OpenBench client container to Ubuntu 23.10 (pre-release). The build errors are as follows:

```
ubuntu@3f49c16f8d1a:~/OpenBench/Scripts/Repositories/Drofa$ gcc --version
gcc (Ubuntu 13.2.0-3ubuntu1) 13.2.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

ubuntu@3f49c16f8d1a:~/OpenBench/Scripts/Repositories/Drofa$ make
g++ -Wall -std=c++11 -O3 -march=native -flto -pthread -fno-exceptions -D_UPEXT_ -c -o obj/bitbase.o src/bitbase.cc
In file included from src/bitbase.cc:19:
src/endgame.h:55:5: error: 'uint8_t' does not name a type
   55 |     uint8_t result;
      |     ^~~~~~~
src/endgame.h:24:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   23 | #include "bitutils.h"
  +++ |+#include <cstdint>
   24 | 
src/bitbase.cc:25:1: error: 'uint8_t' does not name a type
...
```

Arguably, some of the newly added includes are redundant, since \<cstdint\> would be included via another include. But it is often considered a good programming practice not to rely on transitive dependencies, so I didn't make any effort to figure out which are needed and which not. Just a simple `egrep 'int(8|16|32|64)_t' -rl` and fix.
